### PR TITLE
Install Insomnia by default

### DIFF
--- a/mac
+++ b/mac
@@ -174,6 +174,9 @@ install_gui_app "slack" "slack"
 # Android
 install_gui_app "android studio" "android-studio"
 
+# Insomnia
+install_gui_app "insomnia" "insomnia"
+
 fancy_echo "Configuring Ruby ..."
 find_latest_ruby() {
   rbenv install -l | grep -v - | tail -1 | sed -e 's/^ *//'


### PR DESCRIPTION
Since we use Insomnia pretty extensively in course_javascript, we should probably install it as part of the laptop setup script.