### PR TITLE
force java 8 install - intelliJ Gradle plugin doesn't like Java 9

### DIFF
--- a/mac
+++ b/mac
@@ -131,7 +131,10 @@ brew "wget"
 brew "node"
 brew "rbenv"
 brew "ruby-build"
-cask "java"
+
+# Fix for forcing java8 install
+tap "caskroom/versions"
+cask "java8"
 
 # Databases
 brew "postgres", restart_service: true


### PR DESCRIPTION
The laptop script was installing the latest version of Java 9. When you start a new project in the latest version of intelliJ the following error occurs -

`could not determine java version from '9.0.1'`

It seems to be related to intelliJ using an older version of Gradle.

It is possible to `brew install gradle` and then set the project to 'use local gradle distribution' with location `/usr/local/opt/gradle/libexec/` (possibly then using  the env variable of GRADLE_HOME to help intelliJ detect this). But I don't know how valid this is. Seems safer just to implement this java8 fix given the next cohort is due for MYC shortly...