### PR TITLE
Feature/remove junit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ sh mac 2>&1 | tee ~/laptop.log
 * [Git](https://git-scm.com/) for version control
 * [Zsh](http://www.zsh.org/) as your shell
 * [Oh My Zsh](https://github.com/robbyrussell/oh-my-zsh) because we don't hate you
-* [wget](https://www.gnu.org/software/wget/) for downloading files from the Terminal
 
 ### Programming languages and configuration:
 
@@ -47,7 +46,7 @@ sh mac 2>&1 | tee ~/laptop.log
 * [Rbenv](https://github.com/sstephenson/rbenv) for managing versions of Ruby
 * [Bundler](http://bundler.io/) for managing Ruby libraries
 * [Ruby Build](https://github.com/sstephenson/rbenv) for installing Rubies
-* [Java](https://java.com/en/) and [Junit](http://junit.org/) for compiling, running and testing Java code
+* [Java](https://java.com/en/) for compiling and running
 * [Node.js](http://nodejs.org/) for JavaScript back-end development, and
 * [NPM](https://www.npmjs.org/) for installing JavaScript packages
 

--- a/mac
+++ b/mac
@@ -125,7 +125,6 @@ tap "caskroom/fonts"
 # Unix
 brew "git"
 brew "zsh"
-brew "wget"
 
 # Programming languages
 brew "node"
@@ -148,19 +147,6 @@ fancy_echo "Installing Oh-My-Zsh ..."
 curl -L \
   "https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh" | sh
 
-# Junit
-fancy_echo "Installing Junit ..."
-# Download junit
-create_folder_if_not_there "$HOME/junit"
-wget -O "$HOME/junit/junit-4.12.jar" "http://search.maven.org/remotecontent?filepath=junit/junit/4.12/junit-4.12.jar"
-wget -O "$HOME/junit/hamcrest-core-1.3.jar" "http://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-# Add junit to PATH
-append_to_zshrc 'export JUNIT_HOME="$HOME/junit"'
-append_to_zshrc 'export PATH="$PATH:$JUNIT_HOME"'
-# Add Junit to Java CLASSPATH
-append_to_zshrc 'export CLASSPATH="$CLASSPATH:$JUNIT_HOME/junit-4.12.jar:$JUNIT_HOME/hamcrest-core-1.3.jar"'
-# Add alias to provide 'junit' command
-append_to_zshrc 'alias junit="java org.junit.runner.JUnitCore $1"'
 
 fancy_echo "Installing GUI apps"
 

--- a/mac
+++ b/mac
@@ -150,7 +150,7 @@ curl -L \
 
 fancy_echo "Installing GUI apps"
 
-# # Web browsing
+# Web browsing
 install_gui_app "google chrome" "google-chrome"
 
 # Text editing


### PR DESCRIPTION
As we never use junit from the command line anymore, we dont need to install it or put it in the `CLASSPATH`. Within IntelliJ & Android Studio, Gradle handles downloading & making available the appropriate versions of Junit.

The install process for it was pretty hacky and brittle anyway, so personally I'm glad to be able to delete that code 😂