### PR TITLE
Feature/dont output successful installs

### DIFF
--- a/laptop_install_test
+++ b/laptop_install_test
@@ -106,5 +106,3 @@ do
     log_install_success "$gui_app_name"
   fi
 done
-
-cat ~/$log_filename

--- a/mac
+++ b/mac
@@ -226,6 +226,7 @@ install_gui_app "android studio" "android-studio"
 
 fancy_echo "Checking for unsuccessful installs"
 
-curl --remote-name "https://raw.githubusercontent.com/codeclan/laptop/master/laptop_install_test" | sh
+curl --remote-name "https://raw.githubusercontent.com/codeclan/laptop/master/laptop_install_test"
+sh laptop_install_test
 
 fancy_echo "⚠️ Script has finished - please scroll the lines above and bring any errors to an instructor's attention during Meet Your Cohort ⚠️"


### PR DESCRIPTION
This removes the printing of the entire output of the install success check script. Only printing the failures, so that failed installs don't get overlooked in a big list of successes.

Also, piping `curl`'s output into `sh` was causing the `echo`s in the laptop_install_test script to not print at all. I have run the install checker script as a separate command after downloading that script which corrects this.