### PR TITLE
Add Xcode devtools install & loop until they are installed

### DIFF
--- a/mac
+++ b/mac
@@ -64,6 +64,23 @@ install_gui_app() {
   fi
 }
 
+# Check for Xcode Devtools and wait for them to be installed before continuing
+xcode-select -p 2>/dev/null
+return_code=$?
+
+while [ $return_code -eq 2 ]
+do
+  fancy_echo "\033[1;31mApple's Xcode Developer Tools are not installed!\033[0m"
+  fancy_echo "\033[1;31mPlease install them through the dialog box before continuing with running this installation script.\033[0m"
+  fancy_echo "Many of the tools used in this script will not work without the Xcode developer tools"
+  fancy_echo "Opening 'Install Command Line Developer Tools'"
+  xcode-select --install 1>/dev/null
+  fancy_echo "Press enter to try again once Xcode developer tools are installed"
+  read input
+  xcode-select -p
+  return_code=$?
+done
+
 if [ ! -d "$HOME/.bin/" ]; then
   mkdir "$HOME/.bin"
 fi


### PR DESCRIPTION
At the beginning of the script this will run check if the user has the macOS Command Line Developer Tools installed. If they do not, it will run `xcode-select --install`, which opens a prompt to begin the installation process of the CLI Dev Tools. The script will then not continue until the CLI Dev Tools are installed

It does not automatically accept the license agreement. It just pops up the prompt to start the process. The user must then carry out the installation themselves before continuing with the script.