### PR TITLE
Nicely formatted irb output & prompt

### DIFF
--- a/mac
+++ b/mac
@@ -189,9 +189,7 @@ echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
 fancy_echo "Installing and configuring Awesome Print for IRB"
 gem install awesome_print
-if [ ! -f "$HOME/.irbrc" ]; then
-  touch "$HOME/.irbrc"
-fi
+touch "$HOME/.irbrc"
 cat > "$HOME/.irbrc" << EOM
 require "awesome_print"
 AwesomePrint.irb!
@@ -206,9 +204,7 @@ IRB.conf[:PROMPT][:CUSTOM] = {
 }
 IRB.conf[:PROMPT_MODE] = :CUSTOM
 EOM
-if [ ! -f "$HOME/.aprc" ]; then
-  touch "$HOME/.aprc"
-fi
+touch "$HOME/.aprc"
 cat > "$HOME/.aprc" << EOM
 AwesomePrint.defaults = {
   index: false,

--- a/mac
+++ b/mac
@@ -197,6 +197,7 @@ require "awesome_print"
 AwesomePrint.irb!
 require 'irb/completion'
 IRB.conf[:AUTO_INDENT] = true
+IRB.conf[:SAVE_HISTORY] = 1000
 EOM
 if [ ! -f "$HOME/.aprc" ]; then
   touch "$HOME/.aprc"

--- a/mac
+++ b/mac
@@ -188,7 +188,7 @@ fancy_echo "Skipping rdoc generation when we install a gem"
 echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
 fancy_echo "Installing and configuring Awesome Print for IRB"
-gem install awesome_print
+gem_install_or_update 'awesome_print'
 touch "$HOME/.irbrc"
 cat > "$HOME/.irbrc" << EOM
 require "awesome_print"

--- a/mac
+++ b/mac
@@ -196,6 +196,7 @@ cat > "$HOME/.irbrc" << EOM
 require "awesome_print"
 AwesomePrint.irb!
 require 'irb/completion'
+IRB.conf[:AUTO_INDENT] = true
 EOM
 if [ ! -f "$HOME/.aprc" ]; then
   touch "$HOME/.aprc"

--- a/mac
+++ b/mac
@@ -198,6 +198,13 @@ AwesomePrint.irb!
 require 'irb/completion'
 IRB.conf[:AUTO_INDENT] = true
 IRB.conf[:SAVE_HISTORY] = 1000
+IRB.conf[:PROMPT][:CUSTOM] = {
+  :PROMPT_I => 'irb> ',
+  :PROMPT_S => 'irb>%l ',
+  :PROMPT_C => 'irb>> ',
+  :PROMPT_N => 'irb>> '
+}
+IRB.conf[:PROMPT_MODE] = :CUSTOM
 EOM
 if [ ! -f "$HOME/.aprc" ]; then
   touch "$HOME/.aprc"

--- a/mac
+++ b/mac
@@ -195,6 +195,7 @@ fi
 cat > "$HOME/.irbrc" << EOM
 require "awesome_print"
 AwesomePrint.irb!
+require 'irb/completion'
 EOM
 if [ ! -f "$HOME/.aprc" ]; then
   touch "$HOME/.aprc"

--- a/mac
+++ b/mac
@@ -187,6 +187,16 @@ rbenv rehash
 fancy_echo "Skipping rdoc generation when we install a gem"
 echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
+fancy_echo "Installing and configuring Awesome Print for IRB"
+gem install awesome_print
+if [ ! -f "$HOME/.irbrc" ]; then
+  touch "$HOME/.irbrc"
+fi
+cat > "$HOME/.irbrc" << EOM
+require "awesome_print"
+AwesomePrint.irb!
+EOM
+
 if [ -f "$HOME/.laptop.local" ]; then
   fancy_echo "Running your customizations from ~/.laptop.local ..."
   # shellcheck disable=SC1090

--- a/mac
+++ b/mac
@@ -196,6 +196,28 @@ cat > "$HOME/.irbrc" << EOM
 require "awesome_print"
 AwesomePrint.irb!
 EOM
+if [ ! -f "$HOME/.aprc" ]; then
+  touch "$HOME/.aprc"
+fi
+cat > "$HOME/.aprc" << EOM
+AwesomePrint.defaults = {
+  index: false,
+  indent: 2,
+  sort_vars: false,
+  color: {
+    string: :cyanish,
+    symbol: :purple,
+    array: :white,
+    hash: :purpleish,
+    trueclass: :green,
+    falseclass: :red,
+    nilclass: :redish,
+    class: :yellow,
+    integer: :blue,
+    float: :blueish
+  }
+}
+EOM
 
 if [ -f "$HOME/.laptop.local" ]; then
   fancy_echo "Running your customizations from ~/.laptop.local ..."


### PR DESCRIPTION
This PR adds some configuration files for [IRB](https://ruby-doc.org/stdlib-2.0.0/libdoc/irb/rdoc/IRB.htmlv) to format the output of IRB to be more colourful and readable.

I've also configured the prompt to take up less space in the terminal.

All @codeclan/instructors  should probably configure their own IRB to be similar before students laptop's start having this config. You can run this section of the script to get it as I have set it up, or feel free to configure it however you like in [`~/.irbrc`](https://ruby-doc.org/stdlib-2.0.0/libdoc/irb/rdoc/IRB.html#module-IRB-label-Auto+indentation) and [`~/.aprc`](https://github.com/awesome-print/awesome_print#setting-custom-defaults) (replacing `gem_install_or_update` -  a helper function in the installation script, with simply `gem install` )

Before:
<img width="407" alt="screen shot 2018-09-12 at 13 37 08" src="https://user-images.githubusercontent.com/17520022/45692962-eac10c80-bb53-11e8-9a9c-f4289328f849.png">

After:
<img width="322" alt="screen shot 2018-09-18 at 15 02 16" src="https://user-images.githubusercontent.com/17520022/45693079-2f4ca800-bb54-11e8-9859-7c0e450d163b.png">
