### PR TITLE
Switch java8 to openJDK - Oracle version removed from brew

### DIFF
--- a/mac
+++ b/mac
@@ -150,8 +150,8 @@ brew "rbenv"
 brew "ruby-build"
 
 # Fix for forcing java8 install
-tap "caskroom/versions"
-cask "java8"
+tap "adoptopenjdk/openjdk"
+cask "adoptopenjdk/openjdk/adoptopenjdk8"
 
 # Databases
 brew "postgres", restart_service: true


### PR DESCRIPTION
The Oracle version of Java 8 has been removed from Homebrew's `caskroom/versions` tap, and removed from Homebrew altogether. You actually have to *log in* to the Oracle website to download their version 8 JDK.

There are still issues with our code examples in the latest Java version, for now we still need to use JDK 8.

JDK 8 can be installed via homebrew by using the openJDK version.

I have tested this branch's version of the script on a fresh laptop. And then tested multiple start/end point code examples from our java module on that laptop running openJDK 8, both vanilla Java and Spring code, all worked fine.