### PR TITLE
Add creation of generic postgres user role

### DIFF
--- a/mac
+++ b/mac
@@ -235,6 +235,7 @@ fancy_echo "Creating Postgres database under current user name"
 if ! psql -lqt | cut -d \| -f 1 | grep -qw "$(whoami)" >/dev/null; then
   createdb "$(whoami)"
 fi
+createuser "postgres"
 
 # IntelliJ
 fancy_echo "Installing IntelliJ"


### PR DESCRIPTION
Fixes #36 

As discussed in the above linked issue, this adds the creation of a postgres DB user role named "postgres".

This allows anyone who has run this script to work from the same example projects without having to update the DB username of the example project.