### PR TITLE
Adds a more robust check for ruby

### DIFF
--- a/laptop_install_test
+++ b/laptop_install_test
@@ -79,6 +79,16 @@ do
   fi
 done
 
+# Check that a rbenv version of ruby is default, not the system
+which ruby | grep ".rbenv" 2>&1>/dev/null
+if [ $? -ne 0 ] 
+then 
+  log_install_fail "rbenv ruby"
+else
+  log_install_success "rbenv ruby"
+fi
+
+
 is_gui_app_installed() {
   local appNameOrBundleId=$1 bundleId
 


### PR DESCRIPTION
Currently the laptop test script passes even if the system version of ruby is set as default.

This checks that the aliasing to the rbenv installed version has worked.

We can't install gems against the system version.