### PR TITLE
Add python install and text editors/extensions install

### DIFF
--- a/laptop_install_test
+++ b/laptop_install_test
@@ -66,6 +66,7 @@ CLI_APPS=(
   "java"
   "mongod"
   "tree"
+  "pip3"
 )
 
 for cli_app_name in "${CLI_APPS[@]}"

--- a/laptop_install_test
+++ b/laptop_install_test
@@ -146,3 +146,18 @@ case "$liveshare_installed" in
     echo "$message" >> "$HOME/$log_filename"
   ;;
 esac
+
+teletype_installed=$(apm list)
+case "$teletype_installed" in
+  *"teletype"*)
+    message="✅ Teletype extension installed."
+    echo $message
+    echo $message >> "$HOME/$log_filename"
+  ;;
+  *)
+    message="🚫 Teletype extension is NOT installed."
+    echo message
+    echo "$message" 1>&2
+    echo "$message" >> "$HOME/$log_filename"
+  ;;
+esac

--- a/laptop_install_test
+++ b/laptop_install_test
@@ -107,6 +107,7 @@ GUI_APPS=(
   "intellij idea ce"
   "mongodb compass"
   "postico"
+  "visual studio code"
 )
 
 for gui_app_name in "${GUI_APPS[@]}"
@@ -119,3 +120,29 @@ do
     log_install_success "$gui_app_name"
   fi
 done
+
+which_python=$(which python3)
+if [ $which_python != '/usr/local/bin/python3' ]
+then
+  message="🚫 Python path is not correct"
+  echo "$message" 1>&2
+  echo "$message" >> "$HOME/$log_filename"
+else
+  echo "✅ Python path is correct."
+  echo "✅ Python" >> "$HOME/$log_filename"
+fi
+
+liveshare_installed=$(code --list-extensions)
+case "$liveshare_installed" in
+  *"ms-vsliveshare.vsliveshare"*)
+    message="✅ LiveShare extension installed."
+    echo $message
+    echo $message >> "$HOME/$log_filename"
+  ;;
+  *)
+    message="🚫 LiveShare extension is NOT installed."
+    echo message
+    echo "$message" 1>&2
+    echo "$message" >> "$HOME/$log_filename"
+  ;;
+esac

--- a/mac
+++ b/mac
@@ -174,6 +174,7 @@ install_gui_app "google chrome" "google-chrome"
 
 # Text editing
 install_gui_app "atom" "atom"
+apm install teletype
 
 # Chat
 install_gui_app "slack" "slack"

--- a/mac
+++ b/mac
@@ -146,6 +146,7 @@ brew "tree"
 brew "node"
 brew "rbenv"
 brew "ruby-build"
+brew "python"
 
 # Fix for forcing java8 install
 tap "adoptopenjdk/openjdk"
@@ -182,6 +183,14 @@ install_gui_app "insomnia" "insomnia"
 
 # Postico
 install_gui_app "postico" "postico"
+
+# VSCode
+install_gui_app "visual studio code" "visual-studio-code"
+cat << EOF >> ~/.zshrc
+# Add Visual Studio Code (code)
+export PATH="\$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
+EOF
+code --install-extension ms-vsliveshare.vsliveshare
 
 fancy_echo "Configuring Ruby ..."
 find_latest_ruby() {


### PR DESCRIPTION
Adds a brew install of python, which installs pip3 with it.
Add a brew cask install of VSCode, adds to path, then install of LiveShare.
Add apm install of teletype.

Add tests for all of the above.

One issue is that I could only test all the new code in chunks, removing my installs of them and using the new code for the script to get them back - no access to clean laptop to run the entire script from scratch.