### PR TITLE
Updates homebrew install script from deprecated ruby to bash

### DIFF
--- a/mac
+++ b/mac
@@ -125,8 +125,7 @@ gem_install_or_update() {
 
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
-    curl -fsS \
-      'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
     append_to_zshrc '# recommended by brew doctor'
 


### PR DESCRIPTION
[Homebrew](https://brew.sh/) has updated its core install script from Ruby to Bash.  This also appears to enable a number of file permission changes which are necessary for Homebrew components to install as well as the software dependencies for the PSD course.  

The change has been made to the laptop script as newer laptops (particularly student owned machines) don't have the right Ruby setup or file permission structures for the older Ruby Homebrew script to work correctly leading to numerous errors when running the script.

This has been tested on both an existing machine with all the PSD software already installed as well as a completed wiped machine without issues. 